### PR TITLE
Wireframe view implementation

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,9 +16,9 @@ document.addEventListener('DOMContentLoaded', ()=>{
             stage.add([
                 new Placard.ViewGroup.Layer({name: 'grid', opacity: 0.25, hidden: !true})
                 ,
-                new Placard.ViewGroup.Layer({name: 'diagonals', hidden: true})
+                new Placard.ViewGroup.Layer({name: 'wireframe', hidden: !true})
                 ,
-                new Placard.ViewGroup.Layer({name: 'polygon'})
+                new Placard.ViewGroup.Layer({name: 'polygon', hidden: true})
                 ,
             ]);
         
@@ -84,7 +84,7 @@ function setViews(stage) {
                             options: {
                                 strokeStyle: COLORS.blue.value,
                                 points: [ 
-                                    [( 3 * stage.grid.GRIDCELL_DIM ) , ( 3 * stage.grid.GRIDCELL_DIM/*  * Placard.Views.Line.DEFAULT_SIN_ANGLE */ )] 
+                                    [( 3 * stage.grid.GRIDCELL_DIM ) , ( 3 * stage.grid.GRIDCELL_DIM )] 
                                 ]
                                 ,
                                 overrides: {
@@ -108,55 +108,23 @@ function setViews(stage) {
                     ]
                 break;
 
-                case 'diagonals':
-                    // DEV_NOTE # we can write an idiomatic `canvas.stack` and assign an Array with items, whereas each item (if any), is a voided function with it's anonymous implementation:..
+                case 'wireframe':
+                    const { ident, reversed_ident } = Placard.Views.Wireframe.ENUMS.TYPE
                     canvas.stack = [
-                        void function () {
-
-                            // PREREQUISITE # The `context.{translate|rotate|scale}` if any, goes before any paths...
-                            // ...
-            
-                            context.beginPath();
-                                context.moveTo(
-                                    0
-                                    , 
-                                    0
-                                );
-                                context.lineTo(
-                                    window.innerWidth * devicePixelRatio
-                                    , 
-                                    window.innerHeight * devicePixelRatio
-                                );
-                            context.closePath();
-    
-                            context.lineWidth = context.global.options.lineWidth;
-                            context.strokeStyle = 'red';
-                            context.fillStroke();
-    
-                        }()
+                        Placard.Views.Wireframe.draw({
+                            canvas,
+                            options: {
+                                type: ident.value
+                            }
+                        })
                         ,
-                        void function () {
-    
-                            // PREREQUISITE # The `context.{translate|rotate|scale}` if any, goes before any paths...
-                            // ...
-    
-                            context.beginPath();
-                                context.moveTo(
-                                    window.innerWidth * devicePixelRatio
-                                    , 
-                                    0
-                                );
-                                context.lineTo(
-                                    0
-                                    , 
-                                    window.innerHeight * devicePixelRatio
-                                );
-                            context.closePath();
-                            
-                            context.lineWidth = context.global.options.lineWidth;
-                            context.strokeStyle = 'green';
-                            context.fillStroke();
-                        }()
+                        Placard.Views.Wireframe.draw({
+                            canvas,
+                            options: {
+                                type: reversed_ident.value,
+                                strokeStyle: COLORS.red.value
+                            }
+                        })
                         ,
                     ];
                 break;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { stage_view } from './views/stage-view';
 import { layer_view } from './views/layer-view';
 import Grid from "./views/grid";
 import Line from "./views/line";
+import Wireframe from "./views/wireframe";
 
 /**
  * @typedef {Array} Iterable
@@ -46,6 +47,7 @@ export default class {
     static Views = {
         Grid,
         Line,
+        Wireframe,
     }
 
     static Helpers = {

--- a/src/views/wireframe.js
+++ b/src/views/wireframe.js
@@ -1,0 +1,69 @@
+export default class {
+
+    static ENUMS = {
+        TYPE: {
+            ident(){},
+            reversed_ident(){},
+        }
+    }
+
+    static {
+        Object.freeze(this.ENUMS.TYPE)
+    }
+
+    static draw({canvas, options}){
+
+        const context = canvas.getContext('2d');
+        switch (options.type) {
+            // DEV_NOTE (!) # .value is an alias for .name (@see ./src/utils.js)
+            case this.ENUMS.TYPE.ident.value:
+                this.#identDiagonal({context, options});
+                break;
+            case this.ENUMS.TYPE.reversed_ident.value:
+                this.#reversedDiagonal({context, options});
+                break;
+        }
+
+        return true;
+
+    }
+
+    static #identDiagonal({context, options}){
+        context.beginPath();
+            context.moveTo(
+                0
+                , 
+                0
+            );
+            context.lineTo(
+                window.innerWidth * window.devicePixelRatio
+                , 
+                window.innerHeight * window.devicePixelRatio
+            );
+        context.closePath();
+
+        context.lineWidth = options?.lineWidth || context.global.options.lineWidth;
+        context.strokeStyle = options?.strokeStyle || context.global.options.strokeStyle;
+        context.fillStroke();
+    }
+
+    static #reversedDiagonal({context, options}){
+        context.beginPath();
+            context.moveTo(
+                window.innerWidth * window.devicePixelRatio
+                , 
+                0
+            );
+            context.lineTo(
+                0
+                , 
+                window.innerHeight * window.devicePixelRatio
+            );
+        context.closePath();
+
+        context.lineWidth = options?.lineWidth || context.global.options.lineWidth;
+        context.strokeStyle = options?.strokeStyle || context.global.options.strokeStyle;
+        context.fillStroke();
+    }
+
+}


### PR DESCRIPTION
- As titled. Previously it was named as _"diagonals"_ and each call was a `void` function, yet it was somehow cumbersome to have it as an example (see `<root>/main.js`), thus decided to abstract as a separate view implementation (see `<root>/src/views/wireframe.js`)