### PR TITLE
The "snapToGrid" multiplicator value added

### DIFF
--- a/implementation/index.js
+++ b/implementation/index.js
@@ -10,7 +10,7 @@ export default function (stage){
     const { setAngle } = Placard.Helpers.Trigonometry;
 
     Placard
-    .init({stage, stageScale: 25 /* <=== # thumb of rule is between 15-20 (in relative units) */})
+    .init({stage, stageScale: 20 /* <=== # thumb of rule is between 15-20 (in relative units) */})
     .on((context)=>{
 
         if ( UserSettings.init({context}) ) {
@@ -37,7 +37,7 @@ export default function (stage){
                 /* === RIGHT-TRIANGLE === */
                 case 'right-triangle' :
                     // DEV_NOTE # The line below control grouped (i.e. Layer-level) matrix transformation:
-                    context.setTransform(...setAngle(0), stage.grid.X_IN_MIDDLE, stage.grid.Y_IN_MIDDLE);
+                    context.setTransform(...setAngle(-45), stage.grid.X_IN_MIDDLE, stage.grid.Y_IN_MIDDLE);
 
                     stage.layers[canvas.name].addViews([
                         RightTriangle.draw({context})

--- a/implementation/right-triangle.js
+++ b/implementation/right-triangle.js
@@ -17,7 +17,9 @@ export default class {
                 options: {
                     strokeStyle: COLORS.red.value,
                     points: [ 
-                        [( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM ) , ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM/*  * Placard.Views.Line.DEFAULT_SIN_ANGLE */ )],
+                        [
+                            ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * context.snapToGrid ) , ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * context.snapToGrid )
+                        ],
                     ]
                 }
             })
@@ -27,7 +29,9 @@ export default class {
                 options: {
                     strokeStyle: COLORS.green.value,
                     points: [ 
-                        [( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * Placard.Views.Line.RIGHTANGLE_SLOPE ) , ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * Placard.Views.Line.RIGHTANGLE_SLOPE )],
+                        [
+                            ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * Placard.Views.Line.RIGHTANGLE_SLOPE ) , ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * Placard.Views.Line.RIGHTANGLE_SLOPE )
+                        ].map((each)=>each  *= context.snapToGrid),
                     ]
                     ,
                     overrides: {
@@ -43,14 +47,16 @@ export default class {
                 options: {
                     strokeStyle: COLORS.blue.value,
                     points: [ 
-                        [( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM ) , ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM )] 
+                        [
+                            ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * context.snapToGrid ) , ( context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * context.snapToGrid )
+                        ] 
                     ]
                     ,
                     overrides: {
                         transform: {
                             translation: {
-                                x: context.global.options.scalingValue * stage.grid.GRIDCELL_DIM,
-                                y: context.global.options.scalingValue * stage.grid.GRIDCELL_DIM,
+                                x: context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * context.snapToGrid,
+                                y: context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * context.snapToGrid,
                             }
                             ,
                             angle: degToRad(0)

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,9 +43,9 @@ export function responsify({stage, stageScale}){
         ,
         divisorY = Math.ceil( stage?.clientHeight / GRIDCELL_DIM )
         ,
-        X_IN_MIDDLE = ( ( ( divisorX * GRIDCELL_DIM ) ) / 2 )
+        X_IN_MIDDLE = ( ( divisorX * GRIDCELL_DIM ) / 2 )
         ,  
-        Y_IN_MIDDLE = ( ( ( divisorY * GRIDCELL_DIM )  ) / 2 )
+        Y_IN_MIDDLE = ( ( divisorY * GRIDCELL_DIM  ) / 2 )
     ;
 
     stage.grid = {

--- a/src/views/grid.js
+++ b/src/views/grid.js
@@ -15,8 +15,8 @@ export default class grid {
             ;
 
         const context = canvas.getContext('2d');
-            context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0)
-            context.clearRect(0, 0, context.canvas.width, context.canvas.height)
+            context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+            context.clearRect(0, 0, context.canvas.width, context.canvas.height);
         
         /** {@link https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Transformations} */
         function drawGrid(x, y, xLen = gridcellDim, yLen = gridcellDim) {
@@ -32,7 +32,6 @@ export default class grid {
 
         }
 
-        /* const divisorY = Math.ceil( ( context.canvas.clientHeight / gridcellDim ) ); */
         let
             divisorX = Math.ceil( stage.clientWidth / gridcellDim )
             ,

--- a/user-settings.js
+++ b/user-settings.js
@@ -5,7 +5,11 @@ import Placard from './src/index';
  */
 export default class {
 
+    static #snapToGrid = Math.sin(Math.PI/4);
+
     static init({context}){
+
+        context.snapToGrid = this.#snapToGrid;
 
         Object.assign(context, {
             global: {


### PR DESCRIPTION
As titled:
- As of now, when we have a right triangle (_technically can be any view composition_), whose _Layer-level `context`_ for an example is rotated by `Math.PI/4` (i.e. 45 angle degrees) regardless the direction, such right triangle can be nicely snapped to the grid if the `context.snapToGrid` value as multiplicator used correctly (see `./implementation/right-triangle.js` for example).