### PR TITLE
Introducing vector view (arrow tips) over existing line view

### DIFF
--- a/implementation/index.js
+++ b/implementation/index.js
@@ -37,7 +37,7 @@ export default function (stage){
                 /* === RIGHT-TRIANGLE === */
                 case 'right-triangle' :
                     // DEV_NOTE # The line below control grouped (i.e. Layer-level) matrix transformation:
-                    context.setTransform(...setAngle(-45), stage.grid.X_IN_MIDDLE, stage.grid.Y_IN_MIDDLE);
+                    context.setTransform(...setAngle(-135), stage.grid.X_IN_MIDDLE, stage.grid.Y_IN_MIDDLE);
 
                     stage.layers[canvas.name].addViews([
                         RightTriangle.draw({context})

--- a/implementation/right-triangle.js
+++ b/implementation/right-triangle.js
@@ -28,7 +28,8 @@ export default class {
             Placard.Views.Line.draw({
                 canvas,
                 options: {
-                    kind: 'vector',
+                    kind: 'vector', /* DEV_NOTE # can be used with `arrowTip`  */
+                    /* arrowTip : {baseLength : 20, capLength : 20, width : 20}, */// 1^[PASSING]
                     strokeStyle: COLORS.green.value,
                     points: [ 
                         [
@@ -67,7 +68,7 @@ export default class {
                             scale: {
                                 x: 1,
                                 y: -1
-                            } */
+                            } */// # [PASSING]
                         }
                     }
                 }

--- a/implementation/right-triangle.js
+++ b/implementation/right-triangle.js
@@ -15,6 +15,7 @@ export default class {
             Placard.Views.Line.draw({
                 canvas,
                 options: {
+                    kind: 'vector',
                     strokeStyle: COLORS.red.value,
                     points: [ 
                         [
@@ -27,6 +28,7 @@ export default class {
             Placard.Views.Line.draw({
                 canvas,
                 options: {
+                    kind: 'vector',
                     strokeStyle: COLORS.green.value,
                     points: [ 
                         [
@@ -45,6 +47,7 @@ export default class {
             Placard.Views.Line.draw({
                 canvas,
                 options: {
+                    kind: 'vector',
                     strokeStyle: COLORS.blue.value,
                     points: [ 
                         [
@@ -59,12 +62,12 @@ export default class {
                                 y: context.global.options.scalingValue * stage.grid.GRIDCELL_DIM * context.snapToGrid,
                             }
                             ,
-                            angle: degToRad(0)
-                            ,
+                            angle: degToRad(90)
+                            /* ,
                             scale: {
-                                x: -1,
-                                y: 1
-                            }
+                                x: 1,
+                                y: -1
+                            } */
                         }
                     }
                 }

--- a/main.js
+++ b/main.js
@@ -17,8 +17,8 @@ document.addEventListener('DOMContentLoaded', ()=>{
                 ,
                 new Placard.ViewGroup.Layer({name: 'right-triangle', hidden: !true})
                 ,
-                new Placard.ViewGroup.Layer({name: 'ring', hidden: true})
-                ,
+                /* new Placard.ViewGroup.Layer({name: 'ring', hidden: true})
+                , *//* <=== DEV_NOTE (!) # if this is instantiated, session-level (tab) console.log may halt the CPU, due to anti-aliasing part in `setRange(0, 0.1 , 720, false)`, thus commenting it out for now... */
             ]);
         
             if ( setViews(stage) ) {

--- a/src/views/line.js
+++ b/src/views/line.js
@@ -99,10 +99,9 @@ export default class {
                 this.#addArrowTip({
                     context,
                     options,
-                    x1: 0,
-                    y1: 0,
                     x2: (point[0]) * context.global.options.responsiveValue,
                     y2: (point[1]) * context.global.options.responsiveValue,
+                    arrowTip: (options?.arrowTip || {baseLength : (context.global.options.lineWidth * 5), capLength : 0, width : (context.global.options.lineWidth * 5)})
                 });
             });
 
@@ -113,41 +112,43 @@ export default class {
     }
 
     /**
-     * > DEV_NOTE # Kudos to ChatGPT for this algorithm !
+     * > **NOTE** : Kudos to ChatGPT for this algorithm using `Math.atan2` !
      * 
      * ---
      * 
-     * Draws a line with an arrowhead at the end.
-     * @param {number} x1 - Starting x-coordinate of the line
-     * @param {number} y1 - Starting y-coordinate of the line
+     * Draws a line with an arrowhead at the end of the line segment.
      * @param {number} x2 - Ending x-coordinate of the line
      * @param {number} y2 - Ending y-coordinate of the line
-     * @param {number} arrowLength - Length of the arrowhead
-     * @param {number} arrowWidth - Width of the arrowhead (distance between its two wings)
+     * @param {number} [x1] - Starting x-coordinate of the line
+     * @param {number} [y1] - Starting y-coordinate of the line
+     * @param {number} [baseLength] - Base length of the arrowhead
+     * @param {number} [capLength] - Cap length of the arrowhead
+     * @param {number} [width] - Width of the arrowhead (distance between its two "wings")
      */
-    static #addArrowTip({context, options, x1, y1, x2, y2, arrowLength = 20, arrowWidth = 20, h = 0}){
+    static #addArrowTip({context, options, x2, y2, x1 = 0, y1 = 0, arrowTip}){
 
         context.save();
 
-            let { x: offsetX, y: offsetY } = options.overrides?.transform?.translation || {x: 0, y: 0};
+        let { x: offsetX, y: offsetY } = (options.overrides?.transform?.translation || {x: 0, y: 0});
+        let angleXY = (options.overrides?.transform?.angle || 0);
             context.translate(offsetX * context.global.options.responsiveValue, offsetY * context.global.options.responsiveValue)
-            context.rotate((options.overrides?.transform?.angle || 0))
+            context.rotate(angleXY)
 
             // Calculate the angle of the line
             const angle = Math.atan2(y2 - y1, x2 - x1);
         
             // Arrowhead points
-            const arrowAngle1 = angle + Math.atan(arrowWidth / (2 * arrowLength)); // First wing
-            const arrowAngle2 = angle - Math.atan(arrowWidth / (2 * arrowLength)); // Second wing
+            const arrowAngle1 = angle + Math.atan(arrowTip.width / (2 * arrowTip.baseLength)); // First wing
+            const arrowAngle2 = angle - Math.atan(arrowTip.width / (2 * arrowTip.baseLength)); // Second wing
         
-            const arrowX1 = x2 - arrowLength * Math.cos(arrowAngle1);
-            const arrowY1 = y2 - arrowLength * Math.sin(arrowAngle1);
-            const arrowX2 = x2 - arrowLength * Math.cos(arrowAngle2);
-            const arrowY2 = y2 - arrowLength * Math.sin(arrowAngle2);
+            const arrowX1 = x2 - arrowTip.baseLength * Math.cos(arrowAngle1);
+            const arrowY1 = y2 - arrowTip.baseLength * Math.sin(arrowAngle1);
+            const arrowX2 = x2 - arrowTip.baseLength * Math.cos(arrowAngle2);
+            const arrowY2 = y2 - arrowTip.baseLength * Math.sin(arrowAngle2);
             
             // Draw the arrowhead
             context.beginPath();
-            context.moveTo(x2+h, y2+h);
+            context.moveTo(x2 + arrowTip.capLength, y2 + arrowTip.capLength);
             context.lineTo(arrowX1, arrowY1);
             context.lineTo(arrowX2, arrowY2);
             context.closePath();

--- a/src/views/line.js
+++ b/src/views/line.js
@@ -11,6 +11,7 @@ export default class {
         ,
         KIND: {
             line(){},
+            vector(){},
             ring(){},
         }
     }
@@ -42,6 +43,7 @@ export default class {
             }
             if (options.overrides.transform?.angle){
                 context.rotate(options.overrides.transform.angle)
+                context.currentAngle = options.overrides.transform.angle;
             }
             if (options.overrides.transform?.scale){
                 let { x, y } = options.overrides.transform.scale;
@@ -64,7 +66,7 @@ export default class {
                                 ( context.global.options.responsiveValue * ( point[1] ) ) - (options.lineWidth ||  context.global.options.lineWidth)
                             );
                             break;
-                        default /* === 'circle' */:
+                        default /* === ('circle' || 'line') */ :
                             context.moveTo(
                                 0
                                 , 
@@ -84,13 +86,77 @@ export default class {
                     
         context.closePath();
 
-        context.kind = options.kind || 'line';
         context.lineWidth = options.lineWidth || context.global.options.lineWidth;
         context.strokeStyle = options.strokeStyle || context.global.options.strokeStyle;
         context.fillStyle = options.fillStyle || context.global.options.fillStyle;
         context.fillStroke();
+
+        context.restore();
+
+        if (options.kind === this.ENUMS.KIND.vector.value) {
+
+            options.points.forEach((point)=>{
+                this.#addArrowTip({
+                    context,
+                    options,
+                    x1: 0,
+                    y1: 0,
+                    x2: (point[0]) * context.global.options.responsiveValue,
+                    y2: (point[1]) * context.global.options.responsiveValue,
+                });
+            });
+
+        }
+
+        return true;
+
+    }
+
+    /**
+     * > DEV_NOTE # Kudos to ChatGPT for this algorithm !
+     * 
+     * ---
+     * 
+     * Draws a line with an arrowhead at the end.
+     * @param {number} x1 - Starting x-coordinate of the line
+     * @param {number} y1 - Starting y-coordinate of the line
+     * @param {number} x2 - Ending x-coordinate of the line
+     * @param {number} y2 - Ending y-coordinate of the line
+     * @param {number} arrowLength - Length of the arrowhead
+     * @param {number} arrowWidth - Width of the arrowhead (distance between its two wings)
+     */
+    static #addArrowTip({context, options, x1, y1, x2, y2, arrowLength = 20, arrowWidth = 20, h = 0}){
+
+        context.save();
+
+            let { x: offsetX, y: offsetY } = options.overrides?.transform?.translation || {x: 0, y: 0};
+            context.translate(offsetX * context.global.options.responsiveValue, offsetY * context.global.options.responsiveValue)
+            context.rotate((options.overrides?.transform?.angle || 0))
+
+            // Calculate the angle of the line
+            const angle = Math.atan2(y2 - y1, x2 - x1);
         
-        context.restore()
+            // Arrowhead points
+            const arrowAngle1 = angle + Math.atan(arrowWidth / (2 * arrowLength)); // First wing
+            const arrowAngle2 = angle - Math.atan(arrowWidth / (2 * arrowLength)); // Second wing
+        
+            const arrowX1 = x2 - arrowLength * Math.cos(arrowAngle1);
+            const arrowY1 = y2 - arrowLength * Math.sin(arrowAngle1);
+            const arrowX2 = x2 - arrowLength * Math.cos(arrowAngle2);
+            const arrowY2 = y2 - arrowLength * Math.sin(arrowAngle2);
+            
+            // Draw the arrowhead
+            context.beginPath();
+            context.moveTo(x2+h, y2+h);
+            context.lineTo(arrowX1, arrowY1);
+            context.lineTo(arrowX2, arrowY2);
+            context.closePath();
+
+            context.strokeStyle = options.strokeStyle;
+            context.fillStyle = options.fillStyle || context.strokeStyle;
+            context.fillStroke();
+
+        context.restore();
 
         return true;
 


### PR DESCRIPTION
- As of now, every `line` view could be converted to `vector` view, if `options.kind = 'vector'`, optionally providing `options.arrowTip = {baseLength : <number>, capLength : <number>, width : <number>}` configuration object;